### PR TITLE
Fix 0.96.0 and add 1.3.0

### DIFF
--- a/1.3.0/Dockerfile
+++ b/1.3.0/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get install -y \
         lua5.2 \
         liblua5.2-dev
 
-ENV OSM2PGSQL_VERSION=0.96.0 \
+ENV OSM2PGSQL_VERSION=1.3.0 \
     OSMCTOOLS_VERSION=0.8-1
 
 # osm2pgsql

--- a/1.3.0/osm-importer.sh
+++ b/1.3.0/osm-importer.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Rex Tsai <rex.cc.tsai@gmail.com>
+
+echo REGION=${REGION:="asia/taiwan"}
+echo COUNTRY=${COUNTRY:=$(basename $REGION)}
+echo DATADIR=${DATADIR:="/osm"}
+echo PBF=${PBF:=$DATADIR/${COUNTRY}-latest.osm.pbf}
+echo LOOP=${LOOP:=600}
+HOST=download.geofabrik.de
+
+[ -d $DATADIR ] || (echo "$DATADIR not found" && exit -1)
+
+if [ -z $PG_ENV_POSTGRES_PASSWORD ] \
+    || [ -z $PG_ENV_POSTGRES_DB ] \
+    || [ -z $PG_ENV_POSTGRES_USER ] \
+    || [ -z $PG_PORT_5432_TCP_ADDR ] \
+    || [ -z $PG_PORT_5432_TCP_PORT ] ; then
+        echo "missing Progress settings"
+
+cat <<EOF
+PG_PORT_5432_TCP_ADDR=$PG_PORT_5432_TCP_ADDR
+PG_PORT_5432_TCP_PORT=$PG_PORT_5432_TCP_PORT
+PG_ENV_POSTGRES_DB=$PG_ENV_POSTGRES_DB
+PG_ENV_POSTGRES_USER=$PG_ENV_POSTGRES_USER
+PG_ENV_POSTGRES_PASSWORD=$PG_ENV_POSTGRES_PASSWORD
+EOF
+exit 1
+fi
+
+function importosm () {
+    # ping database.
+    echo "SELECT 1;" | PGPASSWORD=$PG_ENV_POSTGRES_PASSWORD \
+        psql --no-password \
+        -h $PG_PORT_5432_TCP_ADDR -p $PG_PORT_5432_TCP_PORT \
+        -U $PG_ENV_POSTGRES_USER $PG_ENV_POSTGRES_DB \
+    || return $?
+
+    UPDATEPBF=$(mktemp -p $DATADIR XXX.pbf)
+    if [ ! -f ${PBF} ] ; then
+        wget -O "${UPDATEPBF}" http://$HOST/${REGION}-latest.osm.pbf \
+            || return $?
+    else
+        osmupdate -v --base-url=$HOST/${REGION}-updates "$PBF" "$UPDATEPBF" \
+            || return $?
+    fi
+    trap "Importing in progress, ignored SIGINT & SIGTERM." SIGINT SIGTERM
+    PGPASSWORD=$PG_ENV_POSTGRES_PASSWORD \
+        osm2pgsql --create --slim --cache 2000 \
+        --host $PG_PORT_5432_TCP_ADDR \
+        --database $PG_ENV_POSTGRES_DB \
+        --username $PG_ENV_POSTGRES_USER \
+        --port $PG_PORT_5432_TCP_PORT \
+        $UPDATEPBF && mv -v $UPDATEPBF $PBF
+}
+
+while : ; do
+    importosm
+    [ $LOOP -eq 0 ] && exit $?
+    sleep $LOOP || exit
+done

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker run --name ${POSTGIS_INSTANCE} \
 REGION="asia/taiwan"
 DATADIR=/osm
 LOOP=600
-VERSION="0.96.0"
+VERSION="1.3.0"
 # run the osm2pgsql instance
 # The osm-importer.sh script will run osmupdate every 600 seconds,
 # to pull latest osm data from

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@ POSTGIS_INSTANCE=${1:-"osmdb"}
 REGION=${2:-"asia/taiwan"}
 DATADIR=/osm
 LOOP=600
-VERSION=${3:-"0.96.0"}
+VERSION=${3:-"1.3.0"}
 
 docker run -t -i --rm \
     --link ${POSTGIS_INSTANCE}:pg \


### PR DESCRIPTION
Had an issue with `rm -rf /tmp/osm2pgsql` crashing the build in 0.96.0.

Also adding [1.3.0](https://github.com/openstreetmap/osm2pgsql/releases/tag/1.3.0) as the current latest latest build. 